### PR TITLE
Cleanup evidence (two changes)

### DIFF
--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -17,7 +17,7 @@ Operator cmp : (0;0;0;0;0;0).
 [idn(C;A)] =def= [spread(spread(spread(C; x.y.y); x.y.y); x.y.x) A].
 [cmp(C;X;Y;Z;f;g)] =def= [spread(spread(spread(spread(C; x.y.y); x.y.y); x.y.y); x.y.x) X Y Z f g].
 
-Tactic rawcat_unfold {
+Tactic rawcat-unfold {
   unfold <RawCat obj hom idn cmp>.
 }.
 
@@ -25,28 +25,28 @@ Tactic autoR {
   reduce; *{auto; reduce}.
 }.
 
-Theorem RawCat_wf : [member(RawCat; U{i'})] {
-  rawcat_unfold; auto.
+Theorem RawCat-wf : [member(RawCat; U{i'})] {
+  rawcat-unfold; auto.
 }.
 
 
-Theorem obj_wf : [{RC:RawCat} member(obj(RC); U{i})] {
-  rawcat_unfold; auto.
+Theorem obj-wf : [{RC:RawCat} member(obj(RC); U{i})] {
+  rawcat-unfold; auto.
 }.
 
-Theorem hom_wf : [
+Theorem hom-wf : [
   {RC:RawCat} {A:obj(RC)} {B:obj(RC)} member(hom(RC;A;B); U{i})
 ] {
-  rawcat_unfold; autoR.
+  rawcat-unfold; autoR.
 }.
 
-Theorem idn_wf : [
+Theorem idn-wf : [
   {RC:RawCat} {A:obj(RC)} member(idn(RC; A); hom(RC; A; A))
 ] {
-  rawcat_unfold; autoR.
+  rawcat-unfold; autoR.
 }.
 
-Theorem cmp_wf : [
+Theorem cmp-wf : [
   {RC:RawCat}
   {X:obj(RC)}
   {Y:obj(RC)}
@@ -55,7 +55,7 @@ Theorem cmp_wf : [
   {g:hom(RC; X; Y)}
     member(cmp(RC;X;Y;Z;f;g); hom(RC; X;Z))
 ] {
-  rawcat_unfold; autoR.
+  rawcat-unfold; autoR.
 }.
 
 Operator LeftIdentity : (0).
@@ -76,65 +76,69 @@ Operator CmpAssoc : (0).
 ].
 
 Tactic isect-RawCat {
-  @{ [|- {RC : RawCat} P] => intro @i'; focus 1 #{ lemma <RawCat_wf> }
+  @{ [|- {RC : RawCat} P] => intro @i'; focus 1 #{ lemma <RawCat-wf> }
    }
 }.
 
 Tactic basic-wf {
-  cut-lemma <obj_wf>;
-  cut-lemma <hom_wf>;
-  cut-lemma <cmp_wf>;
-  auto; ?{(bhyp <obj_wf> | bhyp <hom_wf> | bhyp <cmp_wf>); auto};
+  *{ @{ [|- =(obj(C); obj(C); _)] => cut-lemma <obj-wf>; unfold <member>; bhyp <obj-wf>
+      | [|- =(hom(C;X;Y); hom(C;X;Y); _)] => cut-lemma <hom-wf>; unfold <member>; bhyp <hom-wf>
+      | [|- =(cmp(C;X;Y;Z;f;g); cmp(C;X;Y;Z;f;g); _)] => cut-lemma <cmp-wf>; unfold <member>; bhyp <cmp-wf>
+      }; auto
+   }
 }.
 
-Theorem LeftIdentity_wf : [{RC:RawCat} member(LeftIdentity(RC); U{i})] {
-  unfold <LeftIdentity idn>; isect-RawCat; basic-wf;
-  rawcat_unfold; autoR
+Theorem LeftIdentity-wf : [{RC:RawCat} member(LeftIdentity(RC); U{i})] {
+  isect-RawCat;
+  unfold <LeftIdentity>; auto;
+  basic-wf; rawcat-unfold; autoR
 }.
 
-Theorem RightIdentity_wf : [{RC:RawCat} member(RightIdentity(RC); U{i})] {
-  unfold <RightIdentity>; isect-RawCat; basic-wf;
-  rawcat_unfold; autoR
+Theorem RightIdentity-wf : [{RC:RawCat} member(RightIdentity(RC); U{i})] {
+  isect-RawCat;
+  unfold <RightIdentity>; auto;
+  basic-wf; rawcat-unfold; autoR
 }.
 
-Theorem CmpAssoc_wf : [{RC:RawCat} member(CmpAssoc(RC); U{i})] {
-  unfold <CmpAssoc>; isect-RawCat; basic-wf;
-  rawcat_unfold; autoR
+Theorem CmpAssoc-wf : [{RC:RawCat} member(CmpAssoc(RC); U{i})] {
+  unfold <CmpAssoc>; isect-RawCat; auto;
+  basic-wf
 }.
 
 Operator LawCat : (0).
 [LawCat(RC)] =def= [LeftIdentity(RC) * RightIdentity(RC) * CmpAssoc(RC)].
 
-Tactic lawcat_unfold {
+Tactic lawcat-unfold {
   unfold <LeftIdentity RightIdentity CmpAssoc LawCat>;
-  rawcat_unfold.
+  rawcat-unfold.
 }.
 
 Tactic basic-wf' {
   basic-wf;
-  cut-lemma <LeftIdentity_wf>;
-  cut-lemma <RightIdentity_wf>;
-  cut-lemma <CmpAssoc_wf>;
-  unfold <member>;
-  auto; ?{(bhyp <LeftIdentity_wf> | bhyp <RightIdentity_wf> | bhyp <CmpAssoc_wf>); auto};
+  *{ @{ [|- =(LeftIdentity(C); LeftIdentity(C); _)] => cut-lemma <LeftIdentity-wf>; unfold <member>; bhyp <LeftIdentity-wf>
+      | [|- =(RightIdentity(C); RightIdentity(C); _)] => cut-lemma <RightIdentity-wf>; unfold <member>; bhyp <RightIdentity-wf>
+      | [|- =(CmpAssoc(C); CmpAssoc(C); _)] => cut-lemma <CmpAssoc-wf>; unfold <member>; bhyp <CmpAssoc-wf>
+      }; auto
+   }
 }.
 
-Theorem LawCat_wf : [{RC:RawCat} member(LawCat(RC); U{i})] {
-  unfold <LawCat>; isect-RawCat; basic-wf'
+Theorem LawCat-wf : [{RC:RawCat} member(LawCat(RC); U{i})] {
+  unfold <LawCat>; isect-RawCat; auto;
+  basic-wf'
 }.
 
 Operator Cat : ().
 [Cat] =def= [{C : RawCat | LawCat(C)}].
 
-Tactic cat_unfold {
-  unfold <Cat>; lawcat_unfold.
+Tactic cat-unfold {
+  unfold <Cat>; lawcat-unfold.
 }.
 
 Theorem Cat-wf : [member(Cat; U{i'})] {
   unfold <Cat>; auto;
-  cut-lemma <RawCat_wf>; unfold <member>; auto;
-  cum @i; cut-lemma <LawCat_wf>; unfold <member>; bhyp <LawCat_wf>;
-  auto
+  focus 0 #{cut-lemma <RawCat-wf>; unfold <member>; auto};
+  cut-lemma <LawCat-wf>; cum @i; unfold <member>;
+  bhyp <LawCat-wf>; auto
 }.
 
 Theorem InitialRawCat : [RawCat] {
@@ -147,8 +151,10 @@ Theorem InitialCat : [Cat] {
   unfold <Cat>;
   intro [InitialRawCat] @i;
   unfold <InitialRawCat>;
-  [id, id, cut-lemma <LawCat_wf>; elim #2 [C]];
-  *{lawcat_unfold; auto; reduce}
+  [id, id, cut-lemma <LawCat-wf>; elim #2 [C]; auto];
+
+  |||TODO: we need a rule that says "this is the extract of this lemma, and is thence well-formed"
+  *{lawcat-unfold; auto; reduce}
 }.
 
 Theorem TerminalRawCat : [RawCat] {
@@ -165,9 +171,9 @@ Theorem TerminalCat : [Cat] {
   unfold <Cat>;
   intro [TerminalRawCat] <C> @i; unfold <TerminalRawCat>;
   focus 2 #{
-    cut-lemma <LawCat_wf>; bhyp <LawCat_wf>; auto
+    cut-lemma <LawCat-wf>; bhyp <LawCat-wf>; auto
   };
 
-  *{lawcat_unfold; auto; reduce};
+  *{lawcat-unfold; auto; reduce};
   symmetry; unit-eta
 }.

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -111,6 +111,8 @@ struct
        | EQ_SUBST $ #[_, D, _] => extract D
 
        | ADMIT $ #[] => ``(Variable.named "<<<<<ADMIT>>>>>")
+
+       | LEMMA {label} $ _ => ``(Variable.named label)
        | ASSERT $ #[D, E] => AP $$ #[LAM $$ #[E], extract D]
 
        | ` x => `` x

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -113,7 +113,6 @@ struct
        | ADMIT $ #[] => ``(Variable.named "<<<<<ADMIT>>>>>")
 
        | LEMMA {label} $ _ => ``(Variable.named label)
-       | ASSERT $ #[D, E] => AP $$ #[LAM $$ #[E], extract D]
 
        | ` x => `` x
        | x \ E => x \\ extract E

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -1121,8 +1121,9 @@ struct
           val constraints = SequentLevelSolver.generateConstraints (statement, H >> P)
           val substitution = LevelSolver.Level.resolve constraints
           val shovedEvidence = LevelSolver.subst substitution (Susp.force evidence)
+          val theta = LEMMA {label = lbl}
         in
-          [] BY (fn _ => shovedEvidence)
+          [] BY (fn _ => theta $$ #[])
         end
 
       fun Admit (H >> P) =

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -1064,7 +1064,7 @@ struct
       in
         [ H >> term'
         , H @@ (z, term') >> P
-        ] BY (fn [D, E] => ASSERT $$ #[D, z \\ E]
+        ] BY (fn [D, E] => subst D z E
                | _ => raise Refine)
       end
 

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -43,6 +43,7 @@ struct
     | CEQUAL | APPROX | BASE
 
     | CUSTOM of {label : 'label, arity : Arity.t}
+    | LEMMA of {label : 'label}
     | SO_APPLY
 
   local
@@ -170,6 +171,7 @@ struct
     | eq (MEM, MEM) = true
     | eq (SUBSET, SUBSET) = true
     | eq (CUSTOM o1, CUSTOM o2) = Label.eq (#label o1, #label o2)
+    | eq (LEMMA o1, CUSTOM o2) = Label.eq (#label o1, #label o2)
     | eq (SO_APPLY, SO_APPLY) = true
     | eq (PLUS_EQ, PLUS_EQ) = true
     | eq (PLUS_INTROL, PLUS_INTROL) = true
@@ -313,6 +315,7 @@ struct
        | SUBSET => #[0,1]
 
        | CUSTOM {arity,...} => arity
+       | LEMMA _ => #[]
        | SO_APPLY => #[0,0]
 
   fun toString O =
@@ -432,6 +435,7 @@ struct
        | SUBSET => "subset"
 
        | CUSTOM {label,...} => Label.toString label
+       | LEMMA {label} => Label.toString label
        | SO_APPLY => "so_apply"
 
   local

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -15,7 +15,7 @@ struct
 
     | NAT_EQ | NAT_ELIM | ZERO_EQ | SUCC_EQ | NATREC_EQ
 
-    | ADMIT | ASSERT
+    | ADMIT
     | CEQUAL_EQ | CEQUAL_SYM | CEQUAL_STEP
     | CEQUAL_SUBST | CEQUAL_STRUCT of Arity.t
     | CEQUAL_APPROX
@@ -143,7 +143,6 @@ struct
     | eq (IMAGE_ELIM, IMAGE_ELIM) = true
     | eq (IMAGE_EQ_IND, IMAGE_EQ_IND) = true
     | eq (ADMIT, ADMIT) = true
-    | eq (ASSERT, ASSERT) = true
     | eq (UNIV i, UNIV j) = i = j
     | eq (BASE, BASE) = true
     | eq (VOID, VOID) = true
@@ -274,7 +273,6 @@ struct
        | SUBSET_MEMBER_EQ => #[0,0,1]
 
        | ADMIT => #[]
-       | ASSERT => #[0, 1]
 
        | UNIV i => #[]
        | BASE => #[]
@@ -390,7 +388,6 @@ struct
        | EQ_SUBST => "subst"
        | EQ_SYM => "sym"
        | ADMIT => "<<<<<ADMIT>>>>>"
-       | ASSERT => "assert"
 
        | SUBSET_EQ => "subset-eq"
        | SUBSET_INTRO => "subset-intro"


### PR DESCRIPTION
1. Evidence that was cut in via a lemma used to be inlined; now it is referenced using an operator. The derivations were becoming extremely large as a result of subderivations being repeated again and again.
2. We had an `ASSERT(D; x.E)` derivation, but I realized that this is just a let expression at the level of evidence, so rather than introducing redexes, we can simply replace this with `[D/x]E`.
